### PR TITLE
Update apiVersion of certificates and issuers

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,85 +99,55 @@ This webhook has been tested with [cert-manager] v0.13.1 and Kubernetes v0.17.x 
             kubectl get pods -n cert-manager --watch
             kubectl logs -n cert-manager cert-manager-webhook-gandi-XYZ
 
-6. Create a staging issuer (email addresses with the suffix `example.com` are forbidden):
+6. Create a staging issuer (email addresses with the suffix `example.com` are forbidden).
 
-        cat << EOF | sed "s/invalid@example.com/$email/" | kubectl apply -f -
-        apiVersion: cert-manager.io/v1alpha2
-        kind: Issuer
-        metadata:
-          name: letsencrypt-staging
-          namespace: default
-        spec:
-          acme:
-            # The ACME server URL
-            server: https://acme-staging-v02.api.letsencrypt.org/directory
-            # Email address used for ACME registration
-            email: invalid@example.com
-            # Name of a secret used to store the ACME account private key
-            privateKeySecretRef:
-              name: letsencrypt-staging
-            solvers:
-            - dns01:
-                webhook:
-                  groupName: acme.bwolf.me
-                  solverName: gandi
-                  config:
-                    apiKeySecretRef:
-                      key: api-token
-                      name: gandi-credentials
-        EOF
+    See [letsencrypt-staging-issuer.yaml](examples/issuers/letsencrypt-staging-issuer.yaml)
+
+    Don't forget to replace email `invalid@example.com`.
 
     Check status of the Issuer:
 
         kubectl describe issuer letsencrypt-staging
 
+    You can deploy a ClusterIssuer instead : see [letsencrypt-staging-clusterissuer.yaml](examples/issuers/letsencrypt-staging-clusterissuer.yaml)
+
     *Note*: The production Issuer is [similar][ACME documentation].
 
-7. Issue a [Certificate] for your `$DOMAIN`:
+7. Issue a [Certificate] for your domain: see [certif-example-com.yaml](examples/certificates/certif-example-com.yaml)
 
-        cat << EOF | sed "s/example-com/$DOMAIN/" | kubectl apply -f -
-        apiVersion: cert-manager.io/v1alpha2
-        kind: Certificate
-        metadata:
-          name: example-com
-        spec:
-          dnsNames:
-          - example-com
-          issuerRef:
-            name: letsencrypt-staging
-          secretName: example-com-tls
-        EOF
+    Replace `your-domain` and `your.domain` in the [certif-example-com.yaml](examples/certificates/certif-example-com.yaml)
+
+    Create the Certificate:
+
+        kubectl apply -f ./examples/certificates/certif-example-com.yaml
 
     Check the status of the Certificate:
 
-        kubectl describe certificate $DOMAIN
+        kubectl describe certificate example-com
 
     Display the details like the common name and subject alternative names:
 
-        kubectl get secret $DOMAIN-tls -o yaml
+        kubectl get secret example-com-tls -o yaml
 
-8. Issue a wildcard Certificate for your `$DOMAIN`:
+    If you deployed a ClusterIssuer : use [certif-example-com-clusterissuer.yaml](examples/certificates/certif-example-com-clusterissuer.yaml)
 
-        cat << EOF | sed "s/example-com/$DOMAIN/" | kubectl apply -f -
-        apiVersion: cert-manager.io/v1alpha2
-        kind: Certificate
-        metadata:
-          name: wildcard-example-com
-        spec:
-          dnsNames:
-          - '*.example-com'
-          issuerRef:
-            name: letsencrypt-staging
-          secretName: wildcard-example-com-tls
-        EOF
+8. Issue a wildcard Certificate for your domain: see [certif-wildcard-example-com.yaml](examples/certificates/certif-wildcard-example-com.yaml)
+
+    Replace `your-domain` and `your.domain` in the [certif-wildcard-example-com.yaml](examples/certificates/certif-wildcard-example-com.yaml)
+
+    Create the Certificate:
+
+        kubectl apply -f ./examples/certificates/certif-wildcard-example-com.yaml
 
     Check the status of the Certificate:
 
-        kubectl describe certificate $DOMAIN
+        kubectl describe certificate wildcard-example-com
 
     Display the details like the common name and subject alternative names:
 
-        kubectl get secret wildcard-$DOMAIN-tls -o yaml
+        kubectl get secret wildcard-example-com-tls -o yaml
+
+    If you deployed a ClusterIssuer : use [certif-wildcard-example-com-clusterissuer.yaml](examples/certificates/certif-wildcard-example-com-clusterissuer.yaml)
 
 99. Uninstall this webhook:
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ This webhook has been tested with [cert-manager] v0.13.1 and Kubernetes v0.17.x 
 6. Create a staging issuer (email addresses with the suffix `example.com` are forbidden):
 
         cat << EOF | sed "s/invalid@example.com/$email/" | kubectl apply -f -
-        apiVersion: cert-manager.io/v1alpha2
+        apiVersion: cert-manager.io/v1
         kind: Issuer
         metadata:
           name: letsencrypt-staging
@@ -136,7 +136,7 @@ This webhook has been tested with [cert-manager] v0.13.1 and Kubernetes v0.17.x 
 7. Issue a [Certificate] for your `$DOMAIN`:
 
         cat << EOF | sed "s/example-com/$DOMAIN/" | kubectl apply -f -
-        apiVersion: cert-manager.io/v1alpha2
+        apiVersion: cert-manager.io/v1
         kind: Certificate
         metadata:
           name: example-com
@@ -159,7 +159,7 @@ This webhook has been tested with [cert-manager] v0.13.1 and Kubernetes v0.17.x 
 8. Issue a wildcard Certificate for your `$DOMAIN`:
 
         cat << EOF | sed "s/example-com/$DOMAIN/" | kubectl apply -f -
-        apiVersion: cert-manager.io/v1alpha2
+        apiVersion: cert-manager.io/v1
         kind: Certificate
         metadata:
           name: wildcard-example-com

--- a/deploy/cert-manager-webhook-gandi/templates/apiservice.yaml
+++ b/deploy/cert-manager-webhook-gandi/templates/apiservice.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1alpha1.{{ .Values.groupName }}

--- a/deploy/cert-manager-webhook-gandi/templates/pki.yaml
+++ b/deploy/cert-manager-webhook-gandi/templates/pki.yaml
@@ -1,7 +1,7 @@
 ---
 # Create a selfsigned Issuer, in order to create a root CA certificate for
 # signing webhook serving certificates
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ include "cert-manager-webhook-gandi.selfSignedIssuer" . }}
@@ -17,7 +17,7 @@ spec:
 ---
 
 # Generate a CA Certificate used to sign certificates for the webhook
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "cert-manager-webhook-gandi.rootCACertificate" . }}
@@ -38,7 +38,7 @@ spec:
 ---
 
 # Create an Issuer that uses the above generated CA certificate to issue certs
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ include "cert-manager-webhook-gandi.rootCAIssuer" . }}
@@ -55,7 +55,7 @@ spec:
 ---
 
 # Finally, generate a serving certificate for the webhook to use
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "cert-manager-webhook-gandi.servingCertificate" . }}

--- a/examples/certificates/certif-example-com-clusterissuer.yaml
+++ b/examples/certificates/certif-example-com-clusterissuer.yaml
@@ -1,0 +1,11 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: example-com
+spec:
+  dnsNames:
+  - example.com
+  issuerRef:
+    name: letsencrypt-staging
+    kind: ClusterIssuer
+  secretName: example-com-tls

--- a/examples/certificates/certif-example-com.yaml
+++ b/examples/certificates/certif-example-com.yaml
@@ -1,0 +1,10 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: example-com
+spec:
+  dnsNames:
+  - example.com
+  issuerRef:
+    name: letsencrypt-staging
+  secretName: example-com-tls

--- a/examples/certificates/certif-wildcard-example-com-clusterissuer.yaml
+++ b/examples/certificates/certif-wildcard-example-com-clusterissuer.yaml
@@ -1,0 +1,11 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-example-com
+spec:
+  dnsNames:
+  - '*.example.com'
+  issuerRef:
+    name: letsencrypt-staging
+    kind: ClusterIssuer
+  secretName: wildcard-example-com-tls

--- a/examples/certificates/certif-wildcard-example-com.yaml
+++ b/examples/certificates/certif-wildcard-example-com.yaml
@@ -1,0 +1,10 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-example-com
+spec:
+  dnsNames:
+  - '*.example.com'
+  issuerRef:
+    name: letsencrypt-staging
+  secretName: wildcard-example-com

--- a/examples/issuers/letsencrypt-staging-clusterissuer.yaml
+++ b/examples/issuers/letsencrypt-staging-clusterissuer.yaml
@@ -1,0 +1,22 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    # The ACME server URL
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    # Email address used for ACME registration
+    email: invalid@example.com
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    solvers:
+    - dns01:
+        webhook:
+          groupName: acme.bwolf.me
+          solverName: gandi
+          config:
+            apiKeySecretRef:
+              key: api-token
+              name: gandi-credentials

--- a/examples/issuers/letsencrypt-staging-issuer.yaml
+++ b/examples/issuers/letsencrypt-staging-issuer.yaml
@@ -1,0 +1,23 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: letsencrypt-staging
+  namespace: default
+spec:
+  acme:
+    # The ACME server URL
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    # Email address used for ACME registration
+    email: invalid@example.com
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    solvers:
+    - dns01:
+        webhook:
+          groupName: acme.bwolf.me
+          solverName: gandi
+          config:
+            apiKeySecretRef:
+              key: api-token
+              name: gandi-credentials


### PR DESCRIPTION
This removes a couple of deprecation warnings when installing helm chart or creating issuers and certificates.

- bump `apiVersion` of certificates and issuers to `cert-manager.io/v1`
- upgrade apiservice to `apiregistration.k8s.io/v1`