### PR TITLE
Use default Helm labels

### DIFF
--- a/deploy/cert-manager-webhook-gandi/Chart.yaml
+++ b/deploy/cert-manager-webhook-gandi/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 description: A Helm chart for cert-manager-webhook-gandi
 name: cert-manager-webhook-gandi
-version: v0.2.0
+version: v0.3.0

--- a/deploy/cert-manager-webhook-gandi/templates/_helpers.tpl
+++ b/deploy/cert-manager-webhook-gandi/templates/_helpers.tpl
@@ -31,6 +31,26 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+Common labels
+*/}}
+{{- define "cert-manager-webhook-gandi.labels" -}}
+helm.sh/chart: {{ include "cert-manager-webhook-gandi.chart" . }}
+{{ include "cert-manager-webhook-gandi.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cert-manager-webhook-gandi.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cert-manager-webhook-gandi.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
 {{- define "cert-manager-webhook-gandi.selfSignedIssuer" -}}
 {{ printf "%s-selfsign" (include "cert-manager-webhook-gandi.fullname" .) }}
 {{- end -}}

--- a/deploy/cert-manager-webhook-gandi/templates/apiservice.yaml
+++ b/deploy/cert-manager-webhook-gandi/templates/apiservice.yaml
@@ -3,10 +3,7 @@ kind: APIService
 metadata:
   name: v1alpha1.{{ .Values.groupName }}
   labels:
-    app: {{ include "cert-manager-webhook-gandi.name" . }}
-    chart: {{ include "cert-manager-webhook-gandi.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "cert-manager-webhook-gandi.labels" . | nindent 4 }}
   annotations:
     cert-manager.io/inject-ca-from: "{{ .Values.certManager.namespace }}/{{ include "cert-manager-webhook-gandi.servingCertificate" . }}"
 spec:

--- a/deploy/cert-manager-webhook-gandi/templates/deployment.yaml
+++ b/deploy/cert-manager-webhook-gandi/templates/deployment.yaml
@@ -4,21 +4,16 @@ metadata:
   name: {{ include "cert-manager-webhook-gandi.fullname" . }}
   namespace: {{ .Values.certManager.namespace | quote }}
   labels:
-    app: {{ include "cert-manager-webhook-gandi.name" . }}
-    chart: {{ include "cert-manager-webhook-gandi.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "cert-manager-webhook-gandi.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ include "cert-manager-webhook-gandi.name" . }}
-      release: {{ .Release.Name }}
+      {{- include "cert-manager-webhook-gandi.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ include "cert-manager-webhook-gandi.name" . }}
-        release: {{ .Release.Name }}
+        {{- include "cert-manager-webhook-gandi.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "cert-manager-webhook-gandi.fullname" . }}
       containers:

--- a/deploy/cert-manager-webhook-gandi/templates/pki.yaml
+++ b/deploy/cert-manager-webhook-gandi/templates/pki.yaml
@@ -7,10 +7,7 @@ metadata:
   name: {{ include "cert-manager-webhook-gandi.selfSignedIssuer" . }}
   namespace: {{ .Values.certManager.namespace | quote }}
   labels:
-    app: {{ include "cert-manager-webhook-gandi.name" . }}
-    chart: {{ include "cert-manager-webhook-gandi.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "cert-manager-webhook-gandi.labels" . | nindent 4 }}
 spec:
   selfSigned: {}
 ---
@@ -21,10 +18,7 @@ metadata:
   name: {{ include "cert-manager-webhook-gandi.rootCACertificate" . }}
   namespace: {{ .Values.certManager.namespace | quote }}
   labels:
-    app: {{ include "cert-manager-webhook-gandi.name" . }}
-    chart: {{ include "cert-manager-webhook-gandi.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "cert-manager-webhook-gandi.labels" . | nindent 4 }}
 spec:
   secretName: {{ include "cert-manager-webhook-gandi.rootCACertificate" . }}
   duration: 43800h # 5y
@@ -40,10 +34,7 @@ metadata:
   name: {{ include "cert-manager-webhook-gandi.rootCAIssuer" . }}
   namespace: {{ .Values.certManager.namespace | quote }}
   labels:
-    app: {{ include "cert-manager-webhook-gandi.name" . }}
-    chart: {{ include "cert-manager-webhook-gandi.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "cert-manager-webhook-gandi.labels" . | nindent 4 }}
 spec:
   ca:
     secretName: {{ include "cert-manager-webhook-gandi.rootCACertificate" . }}
@@ -55,10 +46,7 @@ metadata:
   name: {{ include "cert-manager-webhook-gandi.servingCertificate" . }}
   namespace: {{ .Values.certManager.namespace | quote }}
   labels:
-    app: {{ include "cert-manager-webhook-gandi.name" . }}
-    chart: {{ include "cert-manager-webhook-gandi.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "cert-manager-webhook-gandi.labels" . | nindent 4 }}
 spec:
   secretName: {{ include "cert-manager-webhook-gandi.servingCertificate" . }}
   duration: 8760h # 1y

--- a/deploy/cert-manager-webhook-gandi/templates/rbac.yaml
+++ b/deploy/cert-manager-webhook-gandi/templates/rbac.yaml
@@ -4,10 +4,7 @@ metadata:
   name: {{ include "cert-manager-webhook-gandi.fullname" . }}
   namespace: {{ .Values.certManager.namespace | quote }}
   labels:
-    app: {{ include "cert-manager-webhook-gandi.name" . }}
-    chart: {{ include "cert-manager-webhook-gandi.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "cert-manager-webhook-gandi.labels" . | nindent 4 }}
 ---
 # Grant the webhook permission to read the ConfigMap containing the Kubernetes
 # apiserver's requestheader-ca-certificate
@@ -18,10 +15,7 @@ metadata:
   name: {{ include "cert-manager-webhook-gandi.fullname" . }}:webhook-authentication-reader
   namespace: kube-system
   labels:
-    app: {{ include "cert-manager-webhook-gandi.name" . }}
-    chart: {{ include "cert-manager-webhook-gandi.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "cert-manager-webhook-gandi.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -39,10 +33,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "cert-manager-webhook-gandi.fullname" . }}:auth-delegator
   labels:
-    app: {{ include "cert-manager-webhook-gandi.name" . }}
-    chart: {{ include "cert-manager-webhook-gandi.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "cert-manager-webhook-gandi.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -59,10 +50,7 @@ kind: ClusterRole
 metadata:
   name: {{ include "cert-manager-webhook-gandi.fullname" . }}:domain-solver
   labels:
-    app: {{ include "cert-manager-webhook-gandi.name" . }}
-    chart: {{ include "cert-manager-webhook-gandi.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "cert-manager-webhook-gandi.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - {{ .Values.groupName }}
@@ -76,10 +64,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "cert-manager-webhook-gandi.fullname" . }}:domain-solver
   labels:
-    app: {{ include "cert-manager-webhook-gandi.name" . }}
-    chart: {{ include "cert-manager-webhook-gandi.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "cert-manager-webhook-gandi.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -130,10 +115,7 @@ kind: ClusterRole
 metadata:
   name: {{ include "cert-manager-webhook-gandi.fullname" . }}:flowcontrol-solver
   labels:
-    app: {{ include "cert-manager-webhook-gandi.name" . }}
-    chart: {{ include "cert-manager-webhook-gandi.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "cert-manager-webhook-gandi.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - "flowcontrol.apiserver.k8s.io"
@@ -149,10 +131,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "cert-manager-webhook-gandi.fullname" . }}:flowcontrol-solver
   labels:
-    app: {{ include "cert-manager-webhook-gandi.name" . }}
-    chart: {{ include "cert-manager-webhook-gandi.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "cert-manager-webhook-gandi.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deploy/cert-manager-webhook-gandi/templates/service.yaml
+++ b/deploy/cert-manager-webhook-gandi/templates/service.yaml
@@ -4,10 +4,7 @@ metadata:
   name: {{ include "cert-manager-webhook-gandi.fullname" . }}
   namespace: {{ .Values.certManager.namespace | quote }}
   labels:
-    app: {{ include "cert-manager-webhook-gandi.name" . }}
-    chart: {{ include "cert-manager-webhook-gandi.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "cert-manager-webhook-gandi.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:


### PR DESCRIPTION
This pull request make use of the default helpers (created using helm create) to use the [standard helm labels](https://helm.sh/docs/chart_best_practices/labels/#standard-labels).