### PR TITLE
Replace hardcoded container port with value. 

### DIFF
--- a/deploy/cert-manager-webhook-gandi/templates/deployment.yaml
+++ b/deploy/cert-manager-webhook-gandi/templates/deployment.yaml
@@ -26,6 +26,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
+            - --secure-port={{ .Values.containerport }}
             - --tls-cert-file=/tls/tls.crt
             - --tls-private-key-file=/tls/tls.key
 {{- if .Values.logLevel }}
@@ -36,7 +37,7 @@ spec:
               value: {{ .Values.groupName | quote }}
           ports:
             - name: https
-              containerPort: 443
+              containerPort: {{ .Values.containerport }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/deploy/cert-manager-webhook-gandi/templates/service.yaml
+++ b/deploy/cert-manager-webhook-gandi/templates/service.yaml
@@ -12,7 +12,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: https
+      targetPort: {{ .Values.containerport }}
       protocol: TCP
       name: https
   selector:

--- a/deploy/cert-manager-webhook-gandi/values.yaml
+++ b/deploy/cert-manager-webhook-gandi/values.yaml
@@ -12,6 +12,7 @@ fullnameOverride: ''
 service:
   type: ClusterIP
   port: 443
+containerport: 8443
 features:
   apiPriorityAndFairness: false
 resources: {}


### PR DESCRIPTION
The container does not start on openshift (OKD 4.9) because pod security policy / security context constraint disallows container to open port numbers < 1024 .

Other security oriented kubernetes "distros" may be similar. The change does not affect the function of the deployment but just maps target port of the service to the value of container-port and open that port in the container spec.  Also the webhook service is configured to listen to that same port by adding argument --secure-port and set it to the value of containerport which now defaults to 8443. 